### PR TITLE
Expose `uri` for working with Android 10 and beyond.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+- Expose `uri` for file payloads and deprecated `filepath`.
+
 ## 3.0.1
 - Fix issues when running with sound null safety.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.1.0
 - Expose `uri` for file payloads and deprecated `filepath`.
+- Added convinience method `copyFileAndDeleteOriginal` for moving file using
+`uri`.
 
 ## 3.0.1
 - Fix issues when running with sound null safety.

--- a/README.md
+++ b/README.md
@@ -170,15 +170,15 @@ Nearby().sendBytesPayload(endpointId, bytes_array);
 ### Sending File Payload
 You need to send the File Payload and File Name seperately.
 
-File is stored in DOWNLOAD_DIRECTORY and given a generic name
-So you would need to rename the file on receivers end.
+File is stored in `DOWNLOAD_DIRECTORY/.nearby/` and given a generic name.
+You need to copy the file to another directory of your choice.
 
 ```dart
 //creates file with generic name (without extension) in Downloads Directory
 //its your responsibility to rename the file properly
 Nearby().sendFilePayload(endpointId, filePath);
 
-//Send filename as well so that receiver can rename the file
+//Send filename as well so that receiver can move and rename the file
 Nearby().sendBytesPayload(endpointId,fileNameEncodedWithPayloadId);
 //e.g send a string like "payloadId:FileExtensionOrFullName" as bytes
 
@@ -186,9 +186,15 @@ Nearby().sendBytesPayload(endpointId,fileNameEncodedWithPayloadId);
 ```
 Every payload has an **ID** which is same for sender and receiver.
 
-You can get the absolute FilePath from Payload in *onPayloadReceived* function
+You can get the `uri` of the file from Payload in *onPayloadReceived* function.
+We have a convinience method to copy the file to a location you want-
+```dart
+// Convinience method to copy file using it's `uri`.
+final newPath = '${await getExternalStorageDirectory}/$fileName';
+await Nearby().copyFileAndDeleteOriginal(uri, newPath);
+```
 
-Checkout the [**Example**](https://github.com/mannprerak2/nearby_connections/tree/master/example) in Repository for more details
+Checkout the [**Example**](https://github.com/mannprerak2/nearby_connections/tree/master/example) in Repository for more details.
 
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies{
-        api 'com.google.android.gms:play-services-nearby:17.0.0'
+        api 'com.google.android.gms:play-services-nearby:18.0.0'
     }
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -50,6 +50,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -134,7 +148,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.1.0"
   path:
     dependency: transitive
     description:
@@ -142,6 +156,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   pedantic:
     dependency: transitive
     description:
@@ -149,6 +198,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -156,6 +212,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -217,6 +280,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
+  path_provider: ^2.0.2
 
 
 dev_dependencies:

--- a/lib/src/classes.dart
+++ b/lib/src/classes.dart
@@ -15,13 +15,17 @@ class Payload {
   PayloadType type;
 
   Uint8List? bytes;
+
+  @Deprecated('Use uri instead, Only available on Android 10 and below.')
   String? filePath;
+  String? uri;
 
   Payload({
     required this.id,
     this.bytes,
     this.type = PayloadType.NONE,
     this.filePath,
+    this.uri,
   });
 }
 

--- a/lib/src/nearby.dart
+++ b/lib/src/nearby.dart
@@ -97,13 +97,15 @@ class Nearby {
           int type = args['type'] ?? PayloadType.NONE;
           Uint8List bytes = args['bytes'] ?? Uint8List(0);
           int payloadId = args['payloadId'] ?? -1;
-          String filePath = args['filePath'] ?? '';
+          String? filePath = args['filePath'];
+          String? uri = args['uri'];
 
           Payload payload = Payload(
             type: PayloadType.values[type],
             bytes: bytes,
             id: payloadId,
             filePath: filePath,
+            uri: uri,
           );
 
           _onPayloadReceived?.call(endpointId, payload);
@@ -195,6 +197,16 @@ class Nearby {
   /// Use this instead of calling both [askLocationPermission()] and [askExternalStoragePermission()]
   void askLocationAndExternalStoragePermission() =>
       _channel.invokeMethod('askLocationAndExternalStoragePermission');
+
+  /// convenience method
+  ///
+  /// Copy file from [sourceUri] to [destinationFilepath] and delete original.
+  Future<bool> copyFileAndDeleteOriginal(
+          String sourceUri, String destinationFilepath) async =>
+      await _channel.invokeMethod('copyFileAndDeleteOriginal', {
+        'sourceUri': sourceUri,
+        'destinationFilepath': destinationFilepath,
+      });
 
   /// Start Advertising, Discoverers would be able to discover this advertiser.
   ///

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nearby_connections
 description: Plugin for the android NearbyConnections API. Bytes and Files Supported.
-version: 3.0.1
+version: 3.1.0
 homepage: https://github.com/mannprerak2/nearby_connections
 
 environment:


### PR DESCRIPTION
Closes #33 
- Expose `uri` for file payloads and deprecated `filepath`.
- Added convinience method `copyFileAndDeleteOriginal` for moving file using
`uri`.