### PR TITLE
Update nearby connections to 18.7.0 that fixes onEndpointLost not being called. Update example, version, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+- Updated nearby connections (`play-services-nearby:18.4.0` -> `play-services-nearby:18.7.0`)
+
 ## 4.0.0
 - Breaking change: removes all permission/location convenience methods.
 - Please use [permission_handler](https://pub.dev/packages/permission_handler) and

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies{
-        api 'com.google.android.gms:play-services-nearby:18.4.0'
+        api 'com.google.android.gms:play-services-nearby:18.7.0'
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -277,7 +277,7 @@ class _MyBodyState extends State<Body> {
                         },
                         onEndpointLost: (id) {
                           showSnackbar(
-                              "Lost discovered Endpoint: ${endpointMap[id]!.endpointName}, id $id");
+                              "Lost discovered Endpoint: ${endpointMap[id]?.endpointName}, id $id");
                         },
                       );
                       showSnackbar("DISCOVERING: $a");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nearby_connections
 description: Plugin for the android NearbyConnections API. Bytes and Files Supported.
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/mannprerak2/nearby_connections
 
 environment:


### PR DESCRIPTION
Closes #61 

- Updated nearby connections to 18.7.0